### PR TITLE
🔀 :: [#158] 이메일 / 인증코드 입력 칸 제한

### DIFF
--- a/Projects/Feature/Sources/Scene/Auth/AuthCode/AuthCodeViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/AuthCode/AuthCodeViewController.swift
@@ -210,4 +210,14 @@ extension AuthCodeViewController: UITextFieldDelegate {
             viewModel.setupAuthCode(authCode: textField.text ?? "")
         }
     }
+    
+    public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+            if textField == authCodeTextField {
+                let currentText = textField.text ?? ""
+                guard let stringRange = Range(range, in: currentText) else { return false }
+                let updatedText = currentText.replacingCharacters(in: stringRange, with: string)
+                return updatedText.count <= 4
+            }
+            return true
+        }
 }

--- a/Projects/Feature/Sources/Scene/Auth/FindPassword/FindPasswordViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/FindPassword/FindPasswordViewController.swift
@@ -112,4 +112,14 @@ extension FindPasswordViewController: UITextFieldDelegate {
             viewModel.setupEmail(email: emailTextField.text ?? "")
         }
     }
+
+    public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+            if textField == emailTextField {
+                let currentText = textField.text ?? ""
+                guard let stringRange = Range(range, in: currentText) else { return false }
+                let updatedText = currentText.replacingCharacters(in: stringRange, with: string)
+                return updatedText.count <= 6
+            }
+            return true
+        }
 }

--- a/Projects/Feature/Sources/Scene/Auth/SignIn/SignInViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/SignIn/SignInViewController.swift
@@ -295,6 +295,16 @@ extension SignInViewController: UITextFieldDelegate {
         }
     }
     
+    public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+            if textField == emailTextField {
+                let currentText = textField.text ?? ""
+                guard let stringRange = Range(range, in: currentText) else { return false }
+                let updatedText = currentText.replacingCharacters(in: stringRange, with: string)
+                return updatedText.count <= 6
+            }
+            return true
+        }
+    
     public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         if emailTextField.text != "", passwordTextField.text != "" {
             passwordTextField.resignFirstResponder()

--- a/Projects/Feature/Sources/Scene/Auth/SignUp/SignUpViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/SignUp/SignUpViewController.swift
@@ -165,4 +165,14 @@ extension SignUpViewController: UITextFieldDelegate {
             viewModel.setupEmail(email: self.emailTextField.text ?? "")
         }
     }
+    
+    public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+            if textField == emailTextField {
+                let currentText = textField.text ?? ""
+                guard let stringRange = Range(range, in: currentText) else { return false }
+                let updatedText = currentText.replacingCharacters(in: stringRange, with: string)
+                return updatedText.count <= 6
+            }
+            return true
+        }
 }


### PR DESCRIPTION
## 변경사항
SignInVC의 이메일 입력을 6자리로 제한했습니다.
SignUpVC의 이메일 입력을 6자리로 제한했습니다.
FindPasswod의 이메일 입력을 6자리로 제한했습니다.

인증코드의 입력수를 4자리로 제한했습니다.
