### PR TITLE
🔀 :: [#274] QR Scan 중복처리 막음

### DIFF
--- a/Projects/Feature/Sources/Scene/QR/View/StudentQRViewController.swift
+++ b/Projects/Feature/Sources/Scene/QR/View/StudentQRViewController.swift
@@ -3,76 +3,82 @@ import AVFoundation
 import Vision
 
 public class StudentQRViewController: BaseViewController, AVCaptureVideoDataOutputSampleBufferDelegate {
-    
+
     let viewModel = QRCodeViewModel()
-    
+
     let captureSession = AVCaptureSession()
     var previewLayer: AVCaptureVideoPreviewLayer!
-    
+
     let metadataObjectTypes: [AVMetadataObject.ObjectType] = [.qr]
-    
+
+    private var isScanningEnabled = true
+
     private let gomsLogo = UIImageView().then {
         $0.image = .image.gomsWhiteLogo.image
     }
-    
+
     private lazy var closeButton = UIButton().then {
         $0.setImage(.image.gomsCloseButton.image, for: .normal)
         $0.addTarget(self, action: #selector(closeButtonDidTap), for: .touchUpInside)
     }
-    
+
     private let qrFrame = UIImageView().then {
         $0.image = .image.qr.image
     }
-    
-    // MARK: - Life Cycel
+
+    // MARK: - Life Cycle
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.view.backgroundColor = .clear
         self.navigationController?.navigationBar.isHidden = true
         self.navigationItem.hidesBackButton = true
     }
-    
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         setupCamera()
     }
-    
+
     // MARK: - Selector
     @objc func closeButtonDidTap() {
         let mainVC = MainViewController()
         self.navigationController?.pushViewController(mainVC, animated: true)
     }
-    
+
     // MARK: - Add View
     public override func addView() {
         [gomsLogo, closeButton, qrFrame].forEach { self.view.addSubview($0) }
     }
-    
+
     // MARK: - Layout
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         previewLayer.frame = CGRect(x: 0, y: 0, width: bounds.width, height: bounds.height)
     }
-    
+
     public override func setLayout() {
         gomsLogo.snp.makeConstraints {
             $0.top.equalToSuperview().offset(48)
             $0.leading.equalToSuperview()
         }
-        
+
         closeButton.snp.makeConstraints {
             $0.width.height.equalTo(24)
             $0.top.equalToSuperview().offset(64)
             $0.trailing.equalToSuperview().inset(20)
         }
-        
+
         qrFrame.snp.makeConstraints {
             $0.width.height.equalTo(bounds.width * 0.64)
             $0.centerY.centerX.equalToSuperview()
         }
     }
-    
+
     func qrScanResult(result: String) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+            self?.isScanningEnabled = true
+        }
+
         if result == "comeback" {
             let vc = QRResultViewController(resultType: .comeback)
             self.navigationController?.pushViewController(vc, animated: true)
@@ -87,10 +93,10 @@ public class StudentQRViewController: BaseViewController, AVCaptureVideoDataOutp
             self.navigationController?.pushViewController(vc, animated: true)
         }
     }
-    
+
     public func setupCamera() {
         guard let camera = AVCaptureDevice.default(for: .video) else { return }
-        
+
         do {
             let input = try AVCaptureDeviceInput(device: camera)
             captureSession.addInput(input)
@@ -98,70 +104,63 @@ public class StudentQRViewController: BaseViewController, AVCaptureVideoDataOutp
             print(error.localizedDescription)
             return
         }
-        
+
         let output = AVCaptureVideoDataOutput()
         output.setSampleBufferDelegate(self, queue: DispatchQueue(label: "videoQueue"))
         captureSession.addOutput(output)
-        
+
         previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
         previewLayer.videoGravity = .resizeAspectFill
         view.layer.addSublayer(previewLayer)
         [gomsLogo, closeButton, qrFrame].forEach { self.view.addSubview($0) }
-        
+
         DispatchQueue.global().async {
             self.captureSession.startRunning()
         }
     }
-    
+
     public func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
-        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
-        
-        var isScanningEnabled = true
-        guard isScanningEnabled else { return }
-        
-        let request = VNDetectBarcodesRequest { request, error in
+        guard isScanningEnabled, let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+
+        let request = VNDetectBarcodesRequest { [weak self] request, error in
+            guard let self = self else { return }
             if let error = error {
                 print("QR 코드 감지 중 오류 발생: \(error.localizedDescription)")
                 return
             }
-            
+
             guard let barcodes = request.results as? [VNBarcodeObservation] else { return }
-            
+
             for barcode in barcodes {
                 if let payload = barcode.payloadStringValue {
                     DispatchQueue.main.async {
                         let qrFrameRect = self.qrFrame.convert(self.qrFrame.bounds, to: self.view)
-                        
-                        let qrFrameTopLeft = qrFrameRect.origin
-                        let qrFrameTopRight = CGPoint(x: qrFrameRect.maxX, y: qrFrameRect.minY)
-                        let qrFrameBottomLeft = CGPoint(x: qrFrameRect.minX, y: qrFrameRect.maxY)
-                        let qrFrameBottomRight = CGPoint(x: qrFrameRect.maxX, y: qrFrameRect.maxY)
-                        
+
                         let boundingBox = barcode.boundingBox
                         let barcodeTopLeft = CGPoint(x: boundingBox.minX * self.view.bounds.width, y: boundingBox.minY * self.view.bounds.height)
                         let barcodeTopRight = CGPoint(x: boundingBox.maxX * self.view.bounds.width, y: boundingBox.minY * self.view.bounds.height)
                         let barcodeBottomLeft = CGPoint(x: boundingBox.minX * self.view.bounds.width, y: boundingBox.maxY * self.view.bounds.height)
                         let barcodeBottomRight = CGPoint(x: boundingBox.maxX * self.view.bounds.width, y: boundingBox.maxY * self.view.bounds.height)
-                        
+
                         if qrFrameRect.contains(barcodeTopLeft)
                             && qrFrameRect.contains(barcodeTopRight)
                             && qrFrameRect.contains(barcodeBottomLeft)
                             && qrFrameRect.contains(barcodeBottomRight) {
-                            
-                            isScanningEnabled = false
-                            
+
+                            guard self.isScanningEnabled else { return }
+                            self.isScanningEnabled = false
+
                             self.viewModel.outingUUID = UUID(uuidString: payload) ?? UUID()
                             self.viewModel.outing { result in
                                 self.qrScanResult(result: result)
                             }
                             self.captureSession.stopRunning()
                         }
-                        
                     }
                 }
             }
         }
-        
+
         let handler = VNImageRequestHandler(cvPixelBuffer: pixelBuffer, options: [:])
         do {
             try handler.perform([request])


### PR DESCRIPTION
## 💡 개요
### QR Scan 중복처리 막음

## 📃 작업내용
- QR이 중복으로 스캔되는걸 변수의 상태 여부로 막도록 변경했습니다..
- QR 1회 스캔 후 1.5초가 지나면 해당 변수를 다시 QR스캔이 가능하도록 변경하도록 추가했습니다.
