### PR TITLE
🔀 :: [#280] iPad 버전 삭제

### DIFF
--- a/Projects/App/Support/Info.plist
+++ b/Projects/App/Support/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.1</string>
+	<string>1.4.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
## 💡 개요
### iPad 버전 삭제

## 📃 작업내용
- App Target에 info에서 iPhone,iPad 지원에서 iPhone으로 변경했습니다.

