### PR TITLE
🔀 :: [#288] 프로필 화면 반응형 추가

### DIFF
--- a/Projects/App/Sources/Application/AppDelegate.swift
+++ b/Projects/App/Sources/Application/AppDelegate.swift
@@ -2,6 +2,7 @@ import UIKit
 import Firebase
 import UserNotifications
 import Feature
+import AudioToolbox
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -24,7 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func requestNotificationAuthorization() {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound, .carPlay]) { granted, error in
             if let error = error {
                 print("Error requesting notification authorization: \(error.localizedDescription)")
                 return
@@ -62,6 +63,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 extension AppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.banner, .sound, .list])
+
+        AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        completionHandler()
     }
 }
 
@@ -71,6 +78,14 @@ extension AppDelegate: MessagingDelegate {
 
         if let token = fcmToken {
             UserDefaults.standard.set(token, forKey: "FCMToken")
+            notificationViewModel.setupFcmToken(fcmToken: token)
+            notificationViewModel.postFcmToken { success in
+                if success {
+                    print("FCM 토큰 전송 성공")
+                } else {
+                    print("FCM 토큰 전송 실패")
+                }
+            }
         } else {
             print("토큰이 없습니다.")
         }

--- a/Projects/App/Sources/Application/SceneDelegate.swift
+++ b/Projects/App/Sources/Application/SceneDelegate.swift
@@ -5,7 +5,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
     private let refreshTokenManager = GOMSRefreshToken.shared
-    //public let notificationViewModel = NotificationViewModel()
+    public let notificationViewModel = NotificationViewModel()
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
@@ -30,6 +30,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             refreshTokenManager.tokenReissuance { [weak self] success in
                 guard let self = self else { return }
                 if success {
+                    if let savedToken = UserDefaults.standard.string(forKey: "FCMToken") {
+                        notificationViewModel.setupFcmToken(fcmToken: savedToken)
+                        notificationViewModel.setupaccessToken(accessToken: accessToken)
+                        notificationViewModel.postFcmToken { success in
+                            if success {
+                                print("FCM 토큰 전송 성공")
+                            } else {
+                                print("FCM 토큰 전송 실패")
+                            }
+                        }
+                                }
                     self.setRootViewControllerBasedOnAuthority(isSwitchOn: isSwitchOn, adminIsSwitchOn: adminIsSwitchOn)
                 } else {
                     self.showLoginScreen()
@@ -47,26 +58,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         DispatchQueue.main.async {
             if authority == "ROLE_STUDENT_COUNCIL" {
+                let adminMainVC = AdminMainViewController()
+                let navigationController = UINavigationController(rootViewController: adminMainVC)
+                self.window?.rootViewController = navigationController
+
                 if adminIsSwitchOn {
+                    print("Admin Screen: AdminMainViewController with AdminQRViewController")
+                    let adminQRVC = AdminQRViewController()
+                    navigationController.pushViewController(adminQRVC, animated: false)
+                } else {
                     print("Admin Screen: AdminMainViewController")
-
-                    let adminMainVC = AdminMainViewController()
-                    let navigationController = UINavigationController(rootViewController: adminMainVC)
-                    self.window?.rootViewController = navigationController
-
-                    DispatchQueue.main.async {
-                        let adminQRVC = AdminQRViewController()
-
-                        UIView.performWithoutAnimation {
-                            navigationController.pushViewController(adminQRVC, animated: false)
-                        }
-                    }
-                }
-
-
-                else {
-                    print("Admin Screen: AdminMainViewController")
-                    self.window?.rootViewController = UINavigationController(rootViewController: AdminMainViewController())
                 }
             } else if authority == "ROLE_STUDENT" {
                 if isSwitchOn {
@@ -81,6 +82,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             }
         }
     }
+
 
     private func showLoginScreen() {
         DispatchQueue.main.async {

--- a/Projects/App/Support/Info.plist
+++ b/Projects/App/Support/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.6</string>
+	<string>1.4.7</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>FirebaseAppDelegateProxyEnabled</key>

--- a/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
@@ -302,7 +302,27 @@ public class AdminProfileViewController: BaseViewController,UIImagePickerControl
         overrideUserInterfaceStyle = nextMode
         setNeedsStatusBarAppearanceUpdate()
     }
-    
+
+    func setupScrollView() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentView)
+
+        scrollView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+
+        contentView.snp.makeConstraints { make in
+            make.edges.equalTo(scrollView.contentLayoutGuide)
+            make.width.equalTo(scrollView.frameLayoutGuide)
+        }
+
+        contentView.snp.makeConstraints { make in
+            make.height.greaterThanOrEqualTo(view.snp.height).priority(.low)
+        }
+
+        addView()
+    }
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         applySavedTheme()

--- a/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
@@ -484,7 +484,7 @@ public class AdminProfileViewController: BaseViewController,UIImagePickerControl
     
     override func addView() {
         view.addSubview(scrollView)
-        
+
         [
             userProfile,
             userName,
@@ -510,12 +510,12 @@ public class AdminProfileViewController: BaseViewController,UIImagePickerControl
             logoutButton,
             withdrawalButton,
             passwordResetButton
-            
+
         ].forEach {
             self.scrollView.addSubview($0)
         }
     }
-    
+
     override func setLayout() {
         scrollView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
@@ -527,137 +527,135 @@ public class AdminProfileViewController: BaseViewController,UIImagePickerControl
             $0.leading.equalToSuperview().inset(20)
             $0.top.equalToSuperview().inset(16)
         }
-        
+
         userProfilePencil.snp.makeConstraints {
             $0.top.equalTo(userGradeDepartment.snp.top)
             $0.trailing.equalTo(userProfile.snp.trailing)
         }
-        
+
         userName.snp.makeConstraints {
             $0.width.equalTo(50)
             $0.height.equalTo(32)
-            $0.leading.equalTo(userProfile.snp.trailing).inset(-16)
+            $0.leading.equalTo(userProfile.snp.trailing).offset(16)
             $0.top.equalTo(userProfile.snp.top)
         }
-        
+
         userGradeDepartment.snp.makeConstraints {
             $0.height.equalTo(28)
-            $0.top.equalTo(userName.snp.bottom).offset(4)
             $0.leading.equalTo(userName.snp.leading)
+            $0.top.equalTo(userName.snp.bottom).offset(4)
         }
-        
+
         perceptionCount.snp.makeConstraints {
             $0.width.equalTo(60)
             $0.height.equalTo(28)
             $0.trailing.equalToSuperview().inset(20)
             $0.top.equalTo(userName.snp.top).inset(0)
         }
-        
+
         perceptionNum.snp.makeConstraints {
             $0.height.equalTo(32)
             $0.trailing.equalTo(perceptionText.snp.leading).inset(-1)
             $0.top.equalTo(perceptionCount.snp.bottom).offset(4)
         }
-        
+
         perceptionText.snp.makeConstraints {
             $0.width.equalTo(17)
             $0.height.equalTo(32)
             $0.trailing.equalToSuperview().inset(20)
             $0.top.equalTo(perceptionCount.snp.bottom).offset(4)
         }
-        
+
         themeTopLine.snp.makeConstraints {
             $0.height.equalTo(1)
             $0.bottom.equalTo(userProfile.snp.bottom).offset(32)
             $0.leading.equalToSuperview().offset(20)
             $0.trailing.equalToSuperview().inset(20)
         }
-        
+
         themeBottomLine.snp.makeConstraints {
             $0.height.equalTo(1)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.top.equalTo(qrMakeOnDescription.snp.bottom).offset(24)
         }
-        
+
         themeChangText.snp.makeConstraints {
             $0.width.equalTo(93)
             $0.height.equalTo(28)
             $0.top.equalTo(themeTopLine.snp.top).offset(24)
             $0.leading.equalToSuperview().inset(28)
         }
-        
+
         themeChangRec.snp.makeConstraints {
-            $0.width.equalTo(360)
             $0.height.equalTo(64)
+            $0.leading.trailing.equalToSuperview().inset(20)
             $0.top.equalTo(themeChangText.snp.bottom).offset(8)
-            $0.leading.equalToSuperview().offset(20)
-            $0.trailing.equalToSuperview().inset(20)
         }
-        
+
         themeSettingText.snp.makeConstraints {
             $0.width.equalTo(106)
             $0.height.equalTo(28)
             $0.top.equalTo(themeChangRec.snp.top).offset(18)
             $0.leading.equalTo(themeChangRec.snp.leading).offset(12)
         }
-        
+
         themeSettingImg.snp.makeConstraints {
             $0.width.equalTo(24)
             $0.height.equalTo(24)
             $0.top.equalTo(themeChangRec.snp.top).offset(20)
             $0.trailing.equalToSuperview().inset(32)
         }
-        
+
         clockText.snp.makeConstraints {
             $0.width.equalTo(184)
             $0.height.equalTo(28)
             $0.leading.equalToSuperview().inset(28)
             $0.top.equalTo(themeChangRec.snp.bottom).offset(25)
         }
-        
+
         clockDescription.snp.makeConstraints {
             $0.width.equalTo(200)
             $0.height.equalTo(20)
             $0.leading.equalTo(clockText.snp.leading)
             $0.top.equalTo(clockText.snp.bottom)
         }
-        
+
         clockToggleButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(28)
             $0.top.equalTo(themeChangRec.snp.bottom).offset(25)
         }
-        
+
         qrMakeOnText.snp.makeConstraints {
             $0.width.equalTo(184)
             $0.height.equalTo(28)
             $0.leading.equalTo(clockDescription.snp.leading)
             $0.top.equalTo(clockDescription.snp.bottom).offset(25)
         }
-        
+
         qrMakeOnDescription.snp.makeConstraints {
             $0.width.equalTo(184)
             $0.height.equalTo(20)
             $0.leading.equalTo(qrMakeOnText.snp.leading)
             $0.top.equalTo(qrMakeOnText.snp.bottom)
         }
-        
+
         qrMakeOntoggleButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(28)
             $0.top.equalTo(clockDescription.snp.bottom).offset(25)
         }
-        
+
         passwordResetButton.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(bounds.height * 0.08)
             $0.top.equalTo(themeBottomLine.snp.bottom).offset(bounds.height * 0.01)
         }
-        
+
         logoutButton.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview().inset(22)
             $0.height.equalTo(bounds.height * 0.08)
             $0.top.equalTo(passwordResetButton.snp.bottom)
         }
-        
+
         withdrawalButton.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(bounds.height * 0.08)
@@ -665,4 +663,3 @@ public class AdminProfileViewController: BaseViewController,UIImagePickerControl
         }
     }
 }
-

--- a/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
@@ -10,11 +10,14 @@ public class AdminProfileViewController: BaseViewController,UIImagePickerControl
     var cancellables = Set<AnyCancellable>()
     let refreshControl = UIRefreshControl()
     
-    lazy var scrollView = UIScrollView().then {
+    let scrollView = UIScrollView().then {
         $0.translatesAutoresizingMaskIntoConstraints = false
-        $0.isUserInteractionEnabled = true
     }
-    
+
+    let contentView = UIView().then {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+    }
+
     let userProfile = UIImageView().then {
         $0.image = .image.gomsBasicProfile.image
         $0.contentMode = .scaleAspectFill

--- a/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
@@ -325,6 +325,7 @@ public class AdminProfileViewController: BaseViewController,UIImagePickerControl
 
     public override func viewDidLoad() {
         super.viewDidLoad()
+        setupScrollView()
         applySavedTheme()
         self.navigationController?.navigationBar.prefersLargeTitles = false
         profileViewModel.loadProfileInfo { success, authority in

--- a/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
@@ -394,6 +394,7 @@ public class UserProfileViewController: BaseViewController, UIImagePickerControl
 
     public override func viewDidLoad() {
         super.viewDidLoad()
+        setupScrollView()
         applySavedTheme()
         self.navigationController?.navigationBar.prefersLargeTitles = false
         profileViewModel.loadProfileInfo { success, authority in

--- a/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
@@ -12,10 +12,12 @@ public class UserProfileViewController: BaseViewController, UIImagePickerControl
     
     let scrollView = UIScrollView().then {
         $0.translatesAutoresizingMaskIntoConstraints = false
-        $0.isUserInteractionEnabled = true
-        $0.alwaysBounceHorizontal = false
     }
-    
+
+    let contentView = UIView().then {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+    }
+
     let userProfile = UIImageView().then {
         $0.image = .image.gomsBasicProfile.image
         $0.contentMode = .scaleAspectFill

--- a/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
@@ -487,7 +487,7 @@ public class UserProfileViewController: BaseViewController, UIImagePickerControl
     
     override func addView() {
         view.addSubview(scrollView)
-        
+
         [
             userProfile,
             userName,
@@ -517,70 +517,69 @@ public class UserProfileViewController: BaseViewController, UIImagePickerControl
             self.scrollView.addSubview($0)
         }
     }
-    
+
     override func setLayout() {
         scrollView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
-        
+
         userProfile.snp.makeConstraints {
             $0.width.equalTo(64)
             $0.height.equalTo(64)
             $0.leading.equalToSuperview().inset(20)
             $0.top.equalToSuperview().inset(16)
         }
-        
+
         userProfilePencil.snp.makeConstraints {
             $0.top.equalTo(userGradeDepartment.snp.top)
             $0.trailing.equalTo(userProfile.snp.trailing)
         }
-        
+
         userName.snp.makeConstraints {
             $0.width.equalTo(50)
             $0.height.equalTo(32)
-            $0.leading.equalTo(userProfile.snp.trailing).inset(-16)
+            $0.leading.equalTo(userProfile.snp.trailing).offset(16)
             $0.top.equalTo(userProfile.snp.top)
         }
-        
+
         userGradeDepartment.snp.makeConstraints {
             $0.height.equalTo(28)
-            $0.top.equalTo(userName.snp.bottom).offset(4)
             $0.leading.equalTo(userName.snp.leading)
+            $0.top.equalTo(userName.snp.bottom).offset(4)
         }
-        
+
         perceptionCount.snp.makeConstraints {
-            $0.width.equalTo(60)
             $0.height.equalTo(28)
             $0.trailing.equalToSuperview().inset(20)
             $0.top.equalTo(userName.snp.top).inset(0)
         }
-        
+
         perceptionNum.snp.makeConstraints {
             $0.height.equalTo(32)
             $0.trailing.equalTo(perceptionText.snp.leading).inset(-1)
             $0.top.equalTo(perceptionCount.snp.bottom).offset(4)
         }
-        
+
         perceptionText.snp.makeConstraints {
             $0.width.equalTo(17)
             $0.height.equalTo(32)
             $0.trailing.equalToSuperview().inset(20)
             $0.top.equalTo(perceptionCount.snp.bottom).offset(4)
         }
-        
+
         themeTopLine.snp.makeConstraints {
             $0.height.equalTo(1)
             $0.bottom.equalTo(userProfile.snp.bottom).offset(32)
             $0.leading.equalToSuperview().offset(20)
             $0.trailing.equalToSuperview().inset(20)
         }
-        
+
         themeBottomLine.snp.makeConstraints {
             $0.height.equalTo(1)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.top.equalTo(cameraNowOnDescription.snp.bottom).offset(24)
         }
-        
+
         themeChangText.snp.makeConstraints {
             $0.width.equalTo(93)
             $0.height.equalTo(28)
@@ -589,76 +588,75 @@ public class UserProfileViewController: BaseViewController, UIImagePickerControl
         }
 
         themeChangRec.snp.makeConstraints {
-            $0.width.equalTo(360)
             $0.height.equalTo(64)
-            $0.top.equalTo(themeChangText.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview().inset(20)
+            $0.top.equalTo(themeChangText.snp.bottom).offset(8)
         }
-        
+
         themeSettingText.snp.makeConstraints {
             $0.width.equalTo(106)
             $0.height.equalTo(28)
             $0.top.equalTo(themeChangRec.snp.top).offset(18)
             $0.leading.equalTo(themeChangRec.snp.leading).offset(12)
         }
-        
+
         themeSettingImg.snp.makeConstraints {
             $0.width.equalTo(24)
             $0.height.equalTo(24)
             $0.top.equalTo(themeChangRec.snp.top).offset(20)
             $0.trailing.equalToSuperview().inset(32)
         }
-        
+
         clockText.snp.makeConstraints {
             $0.width.equalTo(184)
             $0.height.equalTo(28)
             $0.leading.equalToSuperview().inset(28)
             $0.top.equalTo(themeChangRec.snp.bottom).offset(25)
         }
-        
+
         clockDescription.snp.makeConstraints {
             $0.width.equalTo(200)
             $0.height.equalTo(20)
             $0.leading.equalTo(clockText.snp.leading)
             $0.top.equalTo(clockText.snp.bottom)
         }
-        
+
         clockToggleButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(28)
             $0.top.equalTo(themeChangRec.snp.bottom).offset(25)
         }
-        
+
         cameraNowOnText.snp.makeConstraints {
             $0.width.equalTo(184)
             $0.height.equalTo(28)
             $0.leading.equalTo(clockDescription.snp.leading)
             $0.top.equalTo(clockDescription.snp.bottom).offset(25)
         }
-        
+
         cameraNowOnDescription.snp.makeConstraints {
             $0.width.equalTo(184)
             $0.height.equalTo(20)
             $0.leading.equalTo(cameraNowOnText.snp.leading)
             $0.top.equalTo(cameraNowOnText.snp.bottom)
         }
-        
+
         cameraNowOntoggleButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(28)
             $0.top.equalTo(clockDescription.snp.bottom).offset(25)
         }
-        
+
         passwordResetButton.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(bounds.height * 0.08)
             $0.top.equalTo(themeBottomLine.snp.bottom).offset(bounds.height * 0.01)
         }
-        
+
         logoutButton.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview().inset(22)
             $0.height.equalTo(bounds.height * 0.08)
             $0.top.equalTo(passwordResetButton.snp.bottom)
         }
-        
+
         withdrawalButton.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(bounds.height * 0.08)
@@ -666,5 +664,3 @@ public class UserProfileViewController: BaseViewController, UIImagePickerControl
         }
     }
 }
-
-

--- a/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
@@ -371,7 +371,27 @@ public class UserProfileViewController: BaseViewController, UIImagePickerControl
     public func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
         dismiss(animated: true, completion: nil)
     }
-    
+
+    func setupScrollView() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentView)
+
+        scrollView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+
+        contentView.snp.makeConstraints { make in
+            make.edges.equalTo(scrollView.contentLayoutGuide)
+            make.width.equalTo(scrollView.frameLayoutGuide)
+        }
+
+        contentView.snp.makeConstraints { make in
+            make.height.greaterThanOrEqualTo(view.snp.height).priority(.low)
+        }
+
+        addView()
+    }
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         applySavedTheme()


### PR DESCRIPTION
## 💡 개요
### 프로필 화면 반응형 추가

## 📃 작업내용
- User, Admin ProfileVC에 setupScrollView() 함수 추가
- User, Admin ProfileVC에 ContentView 추가
- 프로필 화면 좌우 스크롤 버그 수정
- Push Notification 진동 추가
- 앱 실행 시 FCM 토큰 서버로 통신 추가
- 로그인 후 어드민 화면 2번 전환되는 오류 수정
- info.plist 1.4.7 version으로 변경

## 🎸 기타
**iPhone 16Pro**

https://github.com/user-attachments/assets/ae50b2da-7f94-4ea0-ab38-3878b12d8d0f

**iPhone SE**

https://github.com/user-attachments/assets/1f143d4a-f311-409e-baf3-dc4fa2b46ed5
