### PR TITLE
🔀 :: [#298] 어드민 메인 페이지 오류 수정

### DIFF
--- a/Projects/App/Support/Info.plist
+++ b/Projects/App/Support/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.8</string>
+	<string>1.4.9</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>FirebaseAppDelegateProxyEnabled</key>

--- a/Projects/App/Support/Info.plist
+++ b/Projects/App/Support/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.9</string>
+	<string>1.5.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>FirebaseAppDelegateProxyEnabled</key>

--- a/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
@@ -92,6 +92,12 @@ public class AdminMainViewController: BaseViewController, UICollectionViewDataSo
         $0.addTarget(self, action: #selector(qrButtonTapped), for: .touchUpInside)
     }
 
+    private func setupNavigationBar() {
+        self.navigationController?.navigationBar.prefersLargeTitles = false
+        self.navigationItem.hidesBackButton = true
+        self.navigationController?.navigationBar.isHidden = true
+    }
+
     private var isVisible: Bool = false
 
     // MARK: - Life Cycle

--- a/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
@@ -110,6 +110,10 @@ public class AdminMainViewController: BaseViewController, UICollectionViewDataSo
                 self?.outingStatusCollectionView.reloadData()
             }
         }
+
+        self.navigationController?.navigationBar.prefersLargeTitles = false
+        self.navigationItem.hidesBackButton = true
+        self.navigationController?.navigationBar.isHidden = true
     }
 
     public override func viewWillDisappear(_ animated: Bool) {
@@ -229,26 +233,24 @@ public class AdminMainViewController: BaseViewController, UICollectionViewDataSo
     private func fetchData() {
         let group = DispatchGroup()
 
-        let tasks: [(@escaping () -> Void) -> Void] = [
-            viewModel.getLateList,
-            { completion in self.viewModel.getProfile { _ in completion() } },
-            viewModel.getOutingList
-        ]
+        group.enter()
+        viewModel.getLateList { [weak self] in group.leave() }
 
-        for task in tasks {
-            group.enter()
-            task {
-                group.leave()
-            }
-        }
+        group.enter()
+        viewModel.getProfile { [weak self] _ in group.leave() }
 
-        group.notify(queue: .main) {
-            guard self.isVisible else {
-                self.refreshControl.endRefreshing()
+        group.enter()
+        viewModel.getOutingList { [weak self] in group.leave() }
+
+        group.notify(queue: .main) { [weak self] in
+            guard let self = self, self.isVisible else {
+                self?.refreshControl.endRefreshing()
                 return
             }
-
+            self.setupProfileView()
             self.setupViewComponents()
+            self.latecomerCollectionView.reloadData()
+            self.outingStatusCollectionView.reloadData()
             self.refreshControl.endRefreshing()
         }
     }

--- a/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
@@ -104,22 +104,8 @@ public class AdminMainViewController: BaseViewController, UICollectionViewDataSo
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         isVisible = true
-
-        viewModel.getProfile { [weak self] _ in
-            self?.setupProfileView()
-        }
-
-        viewModel.getLateList { [weak self] in
-            self?.viewModel.getOutingList { [weak self] in
-                self?.setupViewComponents()
-                self?.latecomerCollectionView.reloadData()
-                self?.outingStatusCollectionView.reloadData()
-            }
-        }
-
-        self.navigationController?.navigationBar.prefersLargeTitles = false
-        self.navigationItem.hidesBackButton = true
-        self.navigationController?.navigationBar.isHidden = true
+        fetchData()
+        setupNavigationBar()
     }
 
     public override func viewWillDisappear(_ animated: Bool) {

--- a/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
@@ -97,24 +97,19 @@ public class AdminMainViewController: BaseViewController, UICollectionViewDataSo
     // MARK: - Life Cycle
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
         isVisible = true
+
         viewModel.getProfile { [weak self] _ in
             self?.setupProfileView()
         }
 
         viewModel.getLateList { [weak self] in
             self?.viewModel.getOutingList { [weak self] in
-                self?.setup()
+                self?.setupViewComponents()
+                self?.latecomerCollectionView.reloadData()
+                self?.outingStatusCollectionView.reloadData()
             }
         }
-
-        latecomerCollectionView.reloadData()
-        outingStatusCollectionView.reloadData()
-
-        self.navigationController?.navigationBar.prefersLargeTitles = false
-        self.navigationItem.hidesBackButton = true
-        self.navigationController?.navigationBar.isHidden = true
     }
 
     public override func viewWillDisappear(_ animated: Bool) {
@@ -232,38 +227,32 @@ public class AdminMainViewController: BaseViewController, UICollectionViewDataSo
     }
 
     private func fetchData() {
-        viewModel.getLateList { [weak self] in
-            guard let self = self else { return }
+        let group = DispatchGroup()
 
-            self.viewModel.getProfile { [weak self] _ in
-                guard let self = self else { return }
+        let tasks: [(@escaping () -> Void) -> Void] = [
+            viewModel.getLateList,
+            { completion in self.viewModel.getProfile { _ in completion() } },
+            viewModel.getOutingList
+        ]
 
-                DispatchQueue.main.async {
-                    guard self.isVisible else {
-                        self.refreshControl.endRefreshing()
-                        return
-                    }
-
-                    self.setupProfileView()
-                    self.viewModel.getOutingList { [weak self] in
-                        guard let self = self else { return }
-
-                        DispatchQueue.main.async {
-                            guard self.isVisible else {
-                                self.refreshControl.endRefreshing()
-                                return
-                            }
-
-                            self.setupViewComponents()
-                            self.latecomerCollectionView.reloadData()
-                            self.outingStatusCollectionView.reloadData()
-                            self.refreshControl.endRefreshing()
-                        }
-                    }
-                }
+        for task in tasks {
+            group.enter()
+            task {
+                group.leave()
             }
         }
+
+        group.notify(queue: .main) {
+            guard self.isVisible else {
+                self.refreshControl.endRefreshing()
+                return
+            }
+
+            self.setupViewComponents()
+            self.refreshControl.endRefreshing()
+        }
     }
+
 
     private func setupViewComponents() {
         self.setup()

--- a/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
@@ -227,38 +227,36 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
     }
 
     private func fetchData() {
+        let group = DispatchGroup()
+
+        group.enter()
         mainViewModel.getLateList { [weak self] in
-            guard let self = self else { return }
+            group.leave()
+        }
 
-            self.mainViewModel.getProfile { [weak self] _ in
-                guard let self = self else { return }
+        group.enter()
+        mainViewModel.getProfile { [weak self] _ in
+            group.leave()
+        }
 
-                DispatchQueue.main.async {
-                    guard self.isVisible else {
-                        self.refreshControl.endRefreshing()
-                        return
-                    }
+        group.enter()
+        mainViewModel.getOutingList { [weak self] in
+            group.leave()
+        }
 
-                    self.setupProfileView()
-                    self.mainViewModel.getOutingList { [weak self] in
-                        guard let self = self else { return }
-
-                        DispatchQueue.main.async {
-                            guard self.isVisible else {
-                                self.refreshControl.endRefreshing()
-                                return
-                            }
-
-                            self.setupViewComponents()
-                            self.latecomerCollectionView.reloadData()
-                            self.outingStatusCollectionView.reloadData()
-                            self.refreshControl.endRefreshing()
-                        }
-                    }
-                }
+        group.notify(queue: .main) { [weak self] in
+            guard let self = self, self.isVisible else {
+                self?.refreshControl.endRefreshing()
+                return
             }
+            self.setupProfileView()
+            self.setupViewComponents()
+            self.latecomerCollectionView.reloadData()
+            self.outingStatusCollectionView.reloadData()
+            self.refreshControl.endRefreshing()
         }
     }
+
 
     private func setupViewComponents() {
         self.setup()

--- a/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
@@ -120,6 +120,13 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         isVisible = true
+
+        mainViewModel.getLateList { [weak self] in
+            self?.mainViewModel.getOutingList { [weak self] in
+                self?.setup()
+            }
+        }
+
         fetchData()
         self.navigationController?.navigationBar.prefersLargeTitles = false
         self.navigationItem.hidesBackButton = true


### PR DESCRIPTION
## 💡 개요
### 어드민 메인 페이지 오류 수정 및 리팩토링을 했습니다.

## 📃 작업내용
**기존 문제점**
순차적 통신: getProfile → getLateList → getOutingList를 차례로 호출
→ 각 API 응답을 기다린 후 다음 API를 호출해 불필요한 대기 시간 발생
→ 총 소요 시간 = 프로필 시간 + 지각자 시간 + 외출자 시간

**개선된 방식**
병렬 통신: 3개의 API를 동시에 호출하고, 모두 완료될 때까지 기다림
→ 총 소요 시간 = 가장 느린 API의 시간
→ 성능 3배 향상

데이터 작업 이후 UI가 변경되도록 했습니다. (다른 뷰에 갔다가 돌아왔을때 UI가 업데이트가 되지 않던 오류 수정)

## 🎸 기타
### 기존에 뷰 이전 후 외출자 리스트 수정 안됐을때
https://github.com/user-attachments/assets/cd59ca7a-0076-4f0b-825b-2e6abb7fb399

### 오류 해결 후 뷰 이전 후에도 외출자 리스트가 변경되도록
https://github.com/user-attachments/assets/620c2ab4-cca2-4b1a-84e4-21fb4910ec6d

