### PR TITLE
🔀 :: [#300] 당겨서 새로고침 권한별 컬러 추가

### DIFF
--- a/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
@@ -147,6 +147,7 @@ public class AdminMainViewController: BaseViewController, UICollectionViewDataSo
     func configureRefreshControl() {
         scrollView.refreshControl = refreshControl
         refreshControl.addTarget(self, action: #selector(handleRefreshControl), for: .valueChanged)
+        refreshControl.tintColor = .color.gomsAdmin.color
     }
 
     @objc func handleRefreshControl() {

--- a/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
@@ -152,6 +152,7 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
     func configureRefreshControl() {
         scrollView.refreshControl = refreshControl
         refreshControl.addTarget(self, action: #selector(handleRefreshControl), for: .valueChanged)
+        refreshControl.tintColor = .color.gomsPrimary.color
     }
 
     @objc func handleRefreshControl() {

--- a/Projects/Feature/Sources/Scene/Outing/Admin/View/AdminOutingStatusViewController.swift
+++ b/Projects/Feature/Sources/Scene/Outing/Admin/View/AdminOutingStatusViewController.swift
@@ -92,6 +92,7 @@ public final class AdminOutingViewController: BaseViewController, AdminOutingCel
     private func configureRefreshControl() {
         outingListCollectionView.refreshControl = refreshControl
         refreshControl.addTarget(self, action: #selector(handleRefreshControl), for: .valueChanged)
+        refreshControl.tintColor = .color.gomsAdmin.color
     }
 
     @objc private func handleRefreshControl() {

--- a/Projects/Feature/Sources/Scene/Outing/User/View/OutingViewController.swift
+++ b/Projects/Feature/Sources/Scene/Outing/User/View/OutingViewController.swift
@@ -107,6 +107,7 @@ public final class OutingViewController: BaseViewController {
     private func configureRefreshControl() {
         outingListCollectionView.refreshControl = refreshControl
         refreshControl.addTarget(self, action: #selector(handleRefreshControl), for: .valueChanged)
+        refreshControl.tintColor = .color.gomsPrimary.color
     }
 
     @objc private func handleRefreshControl() {

--- a/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
@@ -400,6 +400,7 @@ public class AdminProfileViewController: BaseViewController,UIImagePickerControl
     func configureRefreshControl () {
         scrollView.refreshControl = refreshControl
         refreshControl.addTarget(self, action: #selector(handleRefreshControl), for: .valueChanged)
+        refreshControl.tintColor = .color.gomsAdmin.color
     }
     
     @objc func handleRefreshControl() {

--- a/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
@@ -465,6 +465,7 @@ public class UserProfileViewController: BaseViewController, UIImagePickerControl
     func configureRefreshControl () {
         scrollView.refreshControl = refreshControl
         refreshControl.addTarget(self, action: #selector(handleRefreshControl), for: .valueChanged)
+        refreshControl.tintColor = .color.gomsPrimary.color
     }
     
     @objc func handleRefreshControl() {

--- a/Projects/Feature/Sources/Scene/StudentManagement/View/StudentManagementViewController.swift
+++ b/Projects/Feature/Sources/Scene/StudentManagement/View/StudentManagementViewController.swift
@@ -78,6 +78,7 @@ public final class StudentManagementViewController: BaseViewController {
     func configureRefreshControl() {
         studentCollectionView.refreshControl = refreshControl
         refreshControl.addTarget(self, action: #selector(handleRefreshControl), for: .valueChanged)
+        refreshControl.tintColor = .color.gomsAdmin.color
     }
 
     @objc private func handleRefreshControl() {


### PR DESCRIPTION
## 💡 개요
### 당겨서 새로고침 권한별 컬러 추가

## 📃 작업내용
당겨서 새로고침 기능에 권한에 맞는 Tint 컬러를 적용했습니다
- 유저 - GOMS_Primary
- 어드민 - GOMS_Admin

## 🎸 기타
<table>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/28c13763-4210-49a5-be59-26448cf1078f" width="250">
      <br>유저
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/5d3f7279-ff5c-41b9-b431-7590f93cc4ec" width="250">
      <br>어드민
    </td>
  </tr>
</table>